### PR TITLE
Optimizated reorderPhotos in GalleryPhotoService (O(n * m) to O(n + m))

### DIFF
--- a/src/main/java/com/example/photogallery/service/GalleryPhotoService.java
+++ b/src/main/java/com/example/photogallery/service/GalleryPhotoService.java
@@ -204,11 +204,14 @@ public class GalleryPhotoService {
                 gallery
             );
 
-        // Simple O(n^2) is fine for small galleries
+        Map<Long, Integer> desiredIndexByPhotoId = new HashMap<>();
+        for (int i = 0; i < orderedPhotoIds.size(); i++) {
+            desiredIndexByPhotoId.putIfAbsent(orderedPhotoIds.get(i), i);
+        }
+
         for (GalleryPhoto gp : mappings) {
-            Long pid = gp.getPhoto().getId();
-            int index = orderedPhotoIds.indexOf(pid);
-            if (index != -1) {
+            Integer index = desiredIndexByPhotoId.get(gp.getPhoto().getId());
+            if (index != null) {
                 gp.setSortOrder(index);
             }
         }


### PR DESCRIPTION
I did some search and noticed that, in the method `reorderPhotos` the original loop found each photo new position with `orderedPhotoIds.indexOf(photoId)`, a linear scan across the incoming list, run once per existing mapping. A scan inside a loop is the classic shape of an accidental `O(n·m)`: with n mappings and an incoming list of size `m`, the method did up to `n × m` comparisons. The code's own comment called this "fine for small galleries" — true until a gallery's photo count stopped being small.  

To fix this, I created a `HashMap` that keeps the photo Id as a key and the index of the photo as a value. 

Everything outside the hot loop, such as fetching the gallery, loading the mappings, saving them back is unchanged. Only the position lookup changed.

**Two details had to survive the rewrite exactly.** The map is built with `putIfAbsent`, not `put`, that reproduces `indexOf` "first occurrence wins" tie-break when `orderedPhotoIds` contains a duplicate id; a plain `put` would silently let the _last_ occurrence win instead. And a photo id with no match keeps its existing `sortOrder` in both versions, the old code skipped on `index == -1`, the new one skips on `map.get(id) == null`.

The project has no JMH dependency, so the comparison runs on a small standalone harness instead, the two loop bodies lifted verbatim into `OriginalProcessor` and `OptimizedProcessor`, timed with `System.nanoTime()` outside of Maven and Spring entirely, so DB and DI overhead can't blur the algorithmic difference.

```
Sweep
n ∈ {10, 100, 1000, 5000, 10000}
ratio (m/n) ∈ {10%, 50%, 100%}
shape ∈ {sorted, reversed, random}
```
```
Iterations
30 warm-up + 30 measured per combination
System.gc() + settle before timing
```
```
Correctness gate
Both algorithms run on identical input; every sortOrder output compared before trusting the clock
```

Memory was measured separately, via `ThreadMXBean.getThreadAllocatedBytes` with `-XX:-DoEscapeAnalysis`, without it, HotSpot proves the short-lived HashMap never escapes the method and scalar-replaces it away entirely, measuring the JIT's cleverness instead of the algorithm's actual auxiliary-space cost.

---

| GALLERY SIZE (N) | ORIGINAL (MS) | OPTIMIZED (MS) | SPEEDUP |
| :--- | ---: | ---: | ---: |
| 10 | 0.498 | 3.936 | 0.1x |
| 100 | 4.284 | 1.052 | 4.1x |
| 1,000 | 219.8 | 13.0 | 16.9x |
| 5,000 | 4912.3 | 82.7 | 59.4x |
| 10,000 | 19814.9 | 155.2 | 127.7x |

> ratio = 100% (every mapping needs its position resolved) · average of 29 measured iterations across sorted/reversed/random input order.
---

The HashMap isn't free. Both versions allocate roughly the same amount per mapping (mostly autoboxing `long` ids to `Long),` but the optimized version adds one map entry per id in `orderedPhotoIds`, a cost that scales with `m`, not `n`.

---

| GALLERY SIZE (N) | ORIGINAL (BYTES) | OPTIMIZED (BYTES) | EXTRA |
| :--- | ---: | ---: | ---: |
| 10 | 32 | 480 | +448 |
| 100 | 32 | 5,344 | +5,312 |
| 1,000 | 20,984 | 83,432 | +62,448 |
| 5,000 | 116,984 | 420,616 | +303,632 |
| 10,000 | 236,984 | 846,168 | +609,184 |

> ratio = 100%, so m = n here —> extra bytes ≈ 61 × n
---

## Conclusion
Trading a HashMap's worth of allocation, garbage collected the moment the method returns, for a two-order-of-magnitude drop in CPU time is an easy call once a gallery has a few thousand photos, which is exactly the regime a drag-to-reorder UI eventually hits in practice. The one honest caveat: at very small `n` (tens of mappings), building the HashMap can cost more than the linear scan it replaces, the crossover lands somewhere in the low hundreds, not at zero. For a "small galleries" default that the original comment assumed would hold forever, that's the regime worth optimizing for.

Full benchmark output (all ratios × input sizes, both time and memory) is available here:
https://gist.github.com/lucassmnobrega/761a0057a6aa72c6be37dfcfdb96e276

All tests passed.
